### PR TITLE
adiciona controllers para crud de parceiros

### DIFF
--- a/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/Parceiro.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/Parceiro.java
@@ -18,6 +18,9 @@ public class Parceiro {
     @NotNull
     private String nome;
 
+    @NotNull
+    private String tipo;
+
     public Parceiro() {}
 
     public Parceiro(Long id, String nome) {

--- a/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroController.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroController.java
@@ -1,11 +1,14 @@
 package com.tech4all_admin.tech4all_admin.parceiro;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
 
 @RestController
 public class ParceiroController {
@@ -22,5 +25,36 @@ public class ParceiroController {
         parceiroService.createParceiro(parceiroDTO);
         return ResponseEntity.ok("Parceiro criado com sucesso");
     }
+
+    @GetMapping("/parceiro")
+    public List<Parceiro> getParceiros(){
+        return parceiroService.getParceiros();
+    }
+
+    @DeleteMapping("/parceiro")
+    public ResponseEntity<String> deleteParceiro(@RequestParam("idParceiro") Long idParceiro) {
+        try {
+            parceiroService.deleteParceiro(idParceiro);
+            return ResponseEntity.ok().body("deletado");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Erro ao excluir parceiro.");
+        }
+    }
+
+    @PutMapping("/parceiro/{id}")
+    public ResponseEntity<Map<String, String>> atualizarParceiro(
+            @PathVariable Long id,
+            @RequestBody Parceiro parceiroAtualizado) {
+        try {
+            parceiroService.atualizarParceiro(id, parceiroAtualizado);
+            return ResponseEntity.ok(Map.of("mensagem", "Parceiro atualizado com sucesso"));
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("erro", "Parceiro não encontrado"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("erro", "Erro ao atualizar parceiro"));
+        }
+    }
+
+
 
 }

--- a/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.java
@@ -1,8 +1,14 @@
 package com.tech4all_admin.tech4all_admin.parceiro;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ParceiroDTO {
 
+    @JsonProperty("nome")
     private String name;
+
+    @JsonProperty("tipo")
+    private String tipo;
 
     public ParceiroDTO() {
     }
@@ -19,4 +25,11 @@ public class ParceiroDTO {
         this.name = name;
     }
 
+    public String getTipo() {
+        return tipo;
+    }
+
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
 }

--- a/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroRepository.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ParceiroRepository extends JpaRepository<Parceiro, Integer> {}
+public interface ParceiroRepository extends JpaRepository<Parceiro, Integer> {
+    Integer id(Long id);
+}

--- a/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroService.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroService.java
@@ -1,7 +1,11 @@
 package com.tech4all_admin.tech4all_admin.parceiro;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ParceiroService {
@@ -17,7 +21,32 @@ public class ParceiroService {
     public void createParceiro(ParceiroDTO parceiroDTO) {
         Parceiro parceiro = new Parceiro();
         parceiro.setNome(parceiroDTO.getName());
+        parceiro.setTipo(parceiroDTO.getTipo());
         parceiroRepository.save(parceiro);
     }
+
+    public List<Parceiro> getParceiros () {
+        return parceiroRepository.findAll();
+    }
+
+    public void deleteParceiro (Long idParceiro) {
+        parceiroRepository.deleteById(idParceiro.intValue());
+    }
+
+    public void atualizarParceiro(Long id, Parceiro parceiroAtualizado) {
+        Optional<Parceiro> parceiroExistenteOpt = parceiroRepository.findById(id.intValue());
+
+        if (parceiroExistenteOpt.isEmpty()) {
+            throw new EntityNotFoundException("Parceiro não encontrado");
+        }
+
+        Parceiro parceiroExistente = parceiroExistenteOpt.get();
+
+        parceiroExistente.setNome(parceiroAtualizado.getNome());
+        parceiroExistente.setTipo(parceiroAtualizado.getTipo());
+
+        parceiroRepository.save(parceiroExistente);
+    }
+
 
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `Parceiro` module, including the addition of a new field, expanded CRUD operations in the controller and service layers, and updates to the DTO and repository. These changes aim to improve functionality and provide a more comprehensive API for managing `Parceiro` entities.

### Enhancements to the `Parceiro` entity:
- Added a new field `tipo` with `@NotNull` annotation to the `Parceiro` class to store the type of the partner. (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/Parceiro.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/Parceiro.javaR21-R23](diffhunk://#diff-5f4718e631682b159345ba097748a8a8f820edd6fa009f442a990fa74f8ee29aR21-R23))

### Expanded CRUD operations:
- Added `GET`, `DELETE`, and `PUT` endpoints in `ParceiroController` for retrieving, deleting, and updating `Parceiro` entities, including proper exception handling for errors like `EntityNotFoundException`. (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroController.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroController.javaR29-R59](diffhunk://#diff-51702c894649fa88f6dcb3e3c65019f41edc74686ee05cefa851a407bbaae8e0R29-R59))
- Implemented corresponding service methods in `ParceiroService` to support the new endpoints, including logic for updating and deleting entities. (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroService.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroService.javaR24-R51](diffhunk://#diff-17c1ad85e45acf873055d64738f903551dda010914bf60f8986800e0fa7e49ffR24-R51))

### Updates to the `ParceiroDTO`:
- Added `tipo` field with `@JsonProperty` annotation to map JSON input/output for the `ParceiroDTO` class. (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.javaR3-R12](diffhunk://#diff-27c00e48efcc7a72f5ef3aba8b56972e44248035ff3e14882b93d99756a9c11cR3-R12))
- Added getter and setter methods for the `tipo` field in `ParceiroDTO`. (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroDTO.javaR28-R34](diffhunk://#diff-27c00e48efcc7a72f5ef3aba8b56972e44248035ff3e14882b93d99756a9c11cR28-R34))

### Repository adjustments:
- Modified `ParceiroRepository` to include a method `Integer id(Long id)` (though the purpose of this method is unclear and might need refinement). (`src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroRepository.java`, [src/main/java/com/tech4all_admin/tech4all_admin/parceiro/ParceiroRepository.javaL7-R9](diffhunk://#diff-a52723a4e737bd9587e5ea031aa43f54d11546c6db714dfbb0dae361a2369970L7-R9))