### PR TITLE
adiciona origem de front

### DIFF
--- a/src/main/java/com/tech4all_admin/tech4all_admin/security/CorsConfig.java
+++ b/src/main/java/com/tech4all_admin/tech4all_admin/security/CorsConfig.java
@@ -10,7 +10,7 @@ public class CorsConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:4200")
+                .allowedOrigins("http://localhost:4200", "http://localhost:58522")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*");
     }


### PR DESCRIPTION
This pull request updates the `CorsConfig` class to expand the allowed origins for CORS requests. 

* [`src/main/java/com/tech4all_admin/tech4all_admin/security/CorsConfig.java`](diffhunk://#diff-8c91acc09f54023a1897885450dfc6670ab38538f999484b95ceadf90599aea1L13-R13): Added "http://localhost:58522" to the list of allowed origins in the `addCorsMappings` method to support additional local development environments.